### PR TITLE
Add issue for automating Maven Central deployment

### DIFF
--- a/issues/2.md
+++ b/issues/2.md
@@ -1,0 +1,15 @@
+# Automate Maven Central Deployment
+
+## Summary
+Create an agent-accessible task that documents and automates deployment of the RosettaNet Jakarta JAXB artifacts to Maven Central.
+
+## Requirements
+- Document the complete publication workflow, including Gradle configuration updates, credential management, and verification steps.
+- Provide automation guidance for Continuous Integration agents to publish snapshots and releases.
+- Outline safeguards for versioning, signing, and release approvals.
+- Link to any reusable scripts or templates required for agents executing the deployment.
+
+## Acceptance Criteria
+- Issue includes actionable checklist items for agents to follow when deploying to Maven Central.
+- References to Gradle tasks or GitHub Actions are validated and up to date.
+- Reviewers can confirm all necessary secrets and environment variables are specified.


### PR DESCRIPTION
## Summary
- add an agent-focused issue describing the Maven Central deployment workflow
- outline requirements and acceptance criteria for automating publication tasks

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_690abe959a688330b11fa176fe2758c6